### PR TITLE
FAT-198 - Provider results should return a url

### DIFF
--- a/src/SFA.DAS.Apprenticeships.Api.Types/Provider.cs
+++ b/src/SFA.DAS.Apprenticeships.Api.Types/Provider.cs
@@ -15,10 +15,7 @@
         /// Is this provider also an employer
         /// </summary>
         public bool IsEmployerProvider { get; set; }
-
-        /// <summary>
-        /// TODO Uri to the full provider information
-        /// </summary>
+        
         public string Uri { get; set; }
 
         public string Phone { get; set; }

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
@@ -45,6 +45,11 @@
             {
                 var response = _getProviders.GetAllProviders();
 
+                foreach (var provider in response)
+                {
+                    provider.Uri = Resolve(provider.Ukprn);
+                }
+
                 return response;
             }
             catch (Exception e)
@@ -65,12 +70,14 @@
             try
             {
                 var response = _getProviders.GetProviderByUkprn(ukprn);
-
+                
                 if (response == null)
                 {
                     throw HttpResponseFactory.RaiseException(HttpStatusCode.NotFound,
                         $"No provider with Ukprn {ukprn} found");
                 }
+
+                response.Uri = Resolve(response.Ukprn);
 
                 return new List<Provider> { response };
             }
@@ -166,7 +173,7 @@
                 ukprn,
                 location,
                 standardCode);
-
+            
             if (model != null)
             {
                 return model;
@@ -194,6 +201,11 @@
             }
 
             throw new HttpResponseException(HttpStatusCode.NotFound);
+        }
+
+        private string Resolve(int ukprn)
+        {
+            return Url.Link("DefaultApi", new { controller = "providers", ukprn });
         }
     }
 }


### PR DESCRIPTION
Additional Notes:
* Unsure of which endpoints should return the Provider url composed of the ukprn. The endpoints that return Standard and Framework Provider Responses do not have a property for Uri so it has been skipped.
* The API client project only calls the Providers endpoint of the API that return Provider objects which will have the ukprn in the url.