### PR TITLE
BugFix - GetStandardProviderDetails and GetFrameworkProviderDetails endpoints

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
@@ -170,12 +170,13 @@
         [Route("standards/{standardCode}/providers")]
         [ApiExplorerSettings(IgnoreApi = true)]
         [ExceptionHandling]
-        public ApprenticeshipDetails GetStandardProviderDetails(string standardCode, int ukprn, int location)
+        public ApprenticeshipDetails GetStandardProviderDetails(string standardCode, int ukprn, int location, bool hasNonLevyContract = false)
         {
             var model = _apprenticeshipProviderRepository.GetCourseByStandardCode(
                 ukprn,
                 location,
-                standardCode);
+                standardCode,
+                hasNonLevyContract);
 
             if (model != null)
             {
@@ -192,12 +193,13 @@
         [Route("frameworks/{frameworkId}/providers")]
         [ApiExplorerSettings(IgnoreApi = true)]
         [ExceptionHandling]
-        public ApprenticeshipDetails GetFrameworkProviderDetails(string frameworkId, int ukprn, int location)
+        public ApprenticeshipDetails GetFrameworkProviderDetails(string frameworkId, int ukprn, int location, bool hasNonLevyContract = false)
         {
             var model = _apprenticeshipProviderRepository.GetCourseByFrameworkId(
                 ukprn,
                 location,
-                frameworkId);
+                frameworkId,
+                hasNonLevyContract);
 
             if (model != null)
             {

--- a/src/Sfa.Das.ApprenticeshipInfoService.Core/Services/IApprenticeshipProviderRepository.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Core/Services/IApprenticeshipProviderRepository.cs
@@ -4,8 +4,8 @@
 
     public interface IApprenticeshipProviderRepository
     {
-        ApprenticeshipDetails GetCourseByStandardCode(int ukprn, int locationId, string standardCode);
+        ApprenticeshipDetails GetCourseByStandardCode(int ukprn, int locationId, string standardCode, bool hasNonLevyContract);
 
-        ApprenticeshipDetails GetCourseByFrameworkId(int ukprn, int locationId, string frameworkId);
+        ApprenticeshipDetails GetCourseByFrameworkId(int ukprn, int locationId, string frameworkId, bool hasNonLevyContract);
     }
 }

--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ApprenticeshipProviderRepository.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ApprenticeshipProviderRepository.cs
@@ -28,7 +28,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
             _providerMapping = providerMapping;
         }
 
-        public ApprenticeshipDetails GetCourseByStandardCode(int ukprn, int locationId, string standardCode)
+        public ApprenticeshipDetails GetCourseByStandardCode(int ukprn, int locationId, string standardCode, bool hasNonLevyContract)
         {
             try
             {
@@ -37,6 +37,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                         q =>
                         q.Term(t => t.Ukprn, ukprn)
                         && q.Term(t => t.StandardCode, standardCode)
+                        && q.Term(t => t.HasNonLevyContract, hasNonLevyContract)
                         && q.Nested(n => n
                             .Path(p => p.TrainingLocations)
                             .Query(nq => nq.Term(nt => nt.TrainingLocations.First().LocationId, locationId))));
@@ -51,7 +52,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
             }
         }
 
-        public ApprenticeshipDetails GetCourseByFrameworkId(int ukprn, int locationId, string frameworkId)
+        public ApprenticeshipDetails GetCourseByFrameworkId(int ukprn, int locationId, string frameworkId, bool hasNonLevyContract)
         {
             try
             {
@@ -60,6 +61,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                         q =>
                         q.Term(t => t.Ukprn, ukprn)
                         && q.Term(t => t.FrameworkId, frameworkId)
+                        && q.Term(t => t.HasNonLevyContract, hasNonLevyContract)
                         && q.Nested(n => n
                             .Path(p => p.TrainingLocations)
                             .Query(nq => nq.Term(nt => nt.TrainingLocations.First().LocationId, locationId))));


### PR DESCRIPTION
GetStandardProviderDetails and GetFrameworkProviderDetails endpoints take a HasNonLevyContract filter to return apprenticeship provider based on roatp and fcs.