### PR TITLE
Ignoring obsolete properties in the swagger

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/App_Start/SwaggerConfig.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/App_Start/SwaggerConfig.cs
@@ -7,6 +7,7 @@ using Swashbuckle.Application;
 using Swashbuckle.Swagger;
 using WebActivatorEx;
 using Sfa.Das.ApprenticeshipInfoService.Api;
+using Sfa.Das.ApprenticeshipInfoService.Api.Extensions;
 
 [assembly: PreApplicationStartMethod(typeof(SwaggerConfig), "Register")]
 
@@ -118,7 +119,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Api
                         // If you want to post-modify "complex" Schemas once they've been generated, across the board or for a
                         // specific type, you can wire up one or more Schema filters.
                         //
-                        //c.SchemaFilter<ApplySchemaVendorExtensions>();
+                        c.SchemaFilter<ApplySchemaVendorExtensions>();
 
                         // In a Swagger 2.0 document, complex types are typically declared globally and referenced by unique
                         // Schema Id. By default, Swashbuckle does NOT use the full type name in Schema Ids. In most cases, this

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Extensions/ApplySchemaVendorExtensions.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Extensions/ApplySchemaVendorExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Swashbuckle.Swagger;
+
+namespace Sfa.Das.ApprenticeshipInfoService.Api.Extensions
+{
+    internal class ApplySchemaVendorExtensions : Swashbuckle.Swagger.ISchemaFilter
+    {
+        public void Apply(Schema schema, SchemaRegistry schemaRegistry, Type type)
+        {
+            foreach (var prop in type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+                                     .Where(p => p.GetCustomAttributes(typeof(ObsoleteAttribute), true)?.Any() == true))
+                if (schema?.properties?.ContainsKey(prop.Name) == true)
+                    schema?.properties?.Remove(prop.Name);
+        }
+    }
+}

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Sfa.Das.ApprenticeshipInfoService.Api.csproj
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Sfa.Das.ApprenticeshipInfoService.Api.csproj
@@ -345,6 +345,7 @@
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\AssessmentOrgsController.cs" />
     <Compile Include="Controllers\StatsController.cs" />
+    <Compile Include="Extensions\ApplySchemaVendorExtensions.cs" />
     <Compile Include="Helpers\HttpResponseFactory.cs" />
     <Compile Include="Controllers\ProvidersController.cs" />
     <Compile Include="Controllers\StandardsController.cs" />


### PR DESCRIPTION
Removes old fields from the swagger definition but keeps delivering them in the API
