### PR TITLE
ukprn validation

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
@@ -1,4 +1,6 @@
-﻿namespace Sfa.Das.ApprenticeshipInfoService.Api.Controllers
+﻿using System.Text.RegularExpressions;
+
+namespace Sfa.Das.ApprenticeshipInfoService.Api.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -19,6 +21,9 @@
         private readonly IGetProviders _getProviders;
         private readonly IControllerHelper _controllerHelper;
         private readonly IApprenticeshipProviderRepository _apprenticeshipProviderRepository;
+
+        private static readonly Regex UkprnPattern = new Regex(@"^\d{8}");
+        private const string BadUkprnMessage = "the ukprn wasn't 8 digits long";
 
         public ProvidersController(
             IGetProviders getProviders,
@@ -63,9 +68,9 @@
         [ExceptionHandling]
         public Provider Get(long ukprn)
         {
-            if (ukprn.ToString().Length != 8)
+            if (!UkprnPattern.IsMatch(ukprn.ToString()))
             {
-                throw HttpResponseFactory.RaiseException(HttpStatusCode.BadRequest, "The UKPRN should be 8 digits long");
+                throw HttpResponseFactory.RaiseException(HttpStatusCode.BadRequest, BadUkprnMessage);
             }
 
             var response = _getProviders.GetProviderByUkprn(ukprn);

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
@@ -58,10 +58,16 @@
         [SwaggerOperation("GetByUkprn")]
         [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(Provider))]
         [SwaggerResponse(HttpStatusCode.NotFound)]
+        [SwaggerResponse(HttpStatusCode.BadRequest)]
         [Route("providers/{ukprn}")]
         [ExceptionHandling]
         public Provider Get(long ukprn)
         {
+            if (ukprn.ToString().Length != 8)
+            {
+                throw HttpResponseFactory.RaiseException(HttpStatusCode.BadRequest, "The UKPRN should be 8 digits long");
+            }
+
             var response = _getProviders.GetProviderByUkprn(ukprn);
 
             if (response == null)
@@ -95,6 +101,7 @@
         /// <param name="ukprn">UKPRN</param>
         [SwaggerResponse(HttpStatusCode.NoContent)]
         [SwaggerResponse(HttpStatusCode.NotFound)]
+        [SwaggerResponse(HttpStatusCode.BadRequest)]
         [Route("providers/{ukprn}")]
         [ExceptionHandling]
         public void Head(long ukprn)

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Controllers/ProvidersController.cs
@@ -11,7 +11,6 @@
     using Sfa.Das.ApprenticeshipInfoService.Core.Models.Responses;
     using Sfa.Das.ApprenticeshipInfoService.Core.Services;
     using SFA.DAS.Apprenticeships.Api.Types.Providers;
-    using SFA.DAS.NLog.Logger;
     using Swashbuckle.Swagger.Annotations;
     using IControllerHelper = Sfa.Das.ApprenticeshipInfoService.Core.Helpers.IControllerHelper;
 
@@ -20,18 +19,15 @@
         private readonly IGetProviders _getProviders;
         private readonly IControllerHelper _controllerHelper;
         private readonly IApprenticeshipProviderRepository _apprenticeshipProviderRepository;
-        private readonly ILog _logger;
 
         public ProvidersController(
             IGetProviders getProviders,
             IControllerHelper controllerHelper,
-            IApprenticeshipProviderRepository apprenticeshipProviderRepository,
-            ILog logger)
+            IApprenticeshipProviderRepository apprenticeshipProviderRepository)
         {
             _getProviders = getProviders;
             _controllerHelper = controllerHelper;
             _apprenticeshipProviderRepository = apprenticeshipProviderRepository;
-            _logger = logger;
         }
 
         /// <summary>

--- a/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Controllers/ProviderControllerTests.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Controllers/ProviderControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.Routing;
@@ -58,30 +59,33 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Controllers
         [Test]
         public void ShouldReturnProvider()
         {
-            var expected = new Provider() { Ukprn = 1 };
+            var ukprn = 12345678;
+            var expected = new Provider() { Ukprn = ukprn };
 
             _mockGetProviders.Setup(
                 x =>
-                    x.GetProviderByUkprn(1)).Returns(expected);
+                    x.GetProviderByUkprn(ukprn)).Returns(expected);
 
-            var actual = _sut.Get(1);
+            var actual = _sut.Get(ukprn);
 
             actual.ShouldBeEquivalentTo(expected);
-            actual.Uri.Should().Be("http://localhost/providers/1");
+            actual.Uri.Should().Be($"http://localhost/providers/{ukprn}");
         }
 
         [Test]
         public void ShouldReturnProvidersNotFound()
         {
-            var expected = new Provider() { Ukprn = 1 };
+            var ex = Assert.Throws<HttpResponseException>(() => _sut.Get(12345679));
 
-            _mockGetProviders.Setup(
-                x =>
-                    x.GetProviderByUkprn(1)).Returns(expected);
+            Assert.AreEqual(HttpStatusCode.NotFound, ex.Response?.StatusCode);
+        }
 
-            ActualValueDelegate<object> test = () => _sut.Get(-2);
+        [Test]
+        public void AnInvalidUkprnShouldReturnABadRequest()
+        {
+            var ex = Assert.Throws<HttpResponseException>(() => _sut.Get(123456));
 
-            Assert.That(test, Throws.TypeOf<HttpResponseException>());
+            Assert.AreEqual(HttpStatusCode.BadRequest, ex.Response?.StatusCode);
         }
 
         [Test]

--- a/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Controllers/ProviderControllerTests.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Controllers/ProviderControllerTests.cs
@@ -39,8 +39,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Controllers
             _sut = new ProvidersController(
                 _mockGetProviders.Object,
                 _mockControllerHelper.Object,
-                _mockApprenticeshipProviderRepository.Object,
-                _mockLogger.Object);
+                _mockApprenticeshipProviderRepository.Object);
             _sut.Request = new HttpRequestMessage
             {
                 RequestUri = new Uri("http://localhost/providers")


### PR DESCRIPTION
Add validation to 

GET /providers/{ukprn}
HEAD /providers/{ukprn}

so it returns a BAD REQUEST if the ukprn isn't 8 digits long