### PR TITLE
trying to fix a null reference exception

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/QueryHelper.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/QueryHelper.cs
@@ -31,7 +31,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                             .Type(Types.Parse("organisationdocument"))
                             .From(0)
                             .MatchAll());
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
 
         public int GetOrganisationsAmountByStandardId(string standardId)
@@ -46,7 +46,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                                 .Match(m => m
                                     .Field(f => f.StandardCode)
                                     .Query(standardId))));
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
 
         public int GetStandardsByOrganisationIdentifierAmount(string organisationId)
@@ -61,7 +61,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                                 .Match(m => m
                                     .Field(f => f.EpaOrganisationIdentifier)
                                     .Query(organisationId))));
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
 
         public int GetFrameworksTotalAmount()
@@ -73,7 +73,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                             .Type(Types.Parse("frameworkdocument"))
                             .From(0)
                             .MatchAll());
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
 
         public int GetProvidersTotalAmount()
@@ -85,7 +85,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                             .Type(Types.Parse(_providerDocumentType))
                             .From(0)
                             .MatchAll());
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
 
         public int GetStandardsTotalAmount()
@@ -97,7 +97,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                             .Type(Types.Parse("standarddocument"))
                             .From(0)
                             .MatchAll());
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
 
         public int GetProvidersByFrameworkTotalAmount(string frameworkId)
@@ -114,7 +114,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                                     .Field(f => f.FrameworkId)
                                     .Terms(frameworkId))));
 
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
 
         public int GetProvidersByStandardTotalAmount(string standardId)
@@ -131,7 +131,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                                     .Field(f => f.StandardCode)
                                     .Terms(int.Parse(standardId)))));
 
-            return (int)results.HitsMetaData.Total;
+            return (results.HitsMetaData?.Total).HasValue ? 0 : (int)results.HitsMetaData.Total;
         }
     }
 }


### PR DESCRIPTION
2. Object reference not set to an instance of an object.
 
36 instances calling  http://das-prd-apprenticeshipinfoservice.cloudapp.net/assessment-organisations/standards/
 
Example Url
 
http://das-prd-apprenticeshipinfoservice.cloudapp.net/assessment-organisations/standards/80
 
Example Log Output:
 
```
Object reference not set to an instance of an object.
at Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch.QueryHelper.GetOrganisationsAmountByStandardId(String standardId)
   at Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch.AssessmentOrgsRepository.GetOrganisationsByStandardId(String standardId)
   at Sfa.Das.ApprenticeshipInfoService.Api.Controllers.AssessmentOrgsController.GetByStandardId(String id)
   at lambda_method(Closure , Object , Object[] )
   at System.Web.Http.Controllers.ReflectedHttpActionDescriptor.ActionExecutor.<>c__DisplayClass10.<GetExecutor>b__9(Object instance, Object[] methodParameters)
   at System.Web.Http.Controllers.ReflectedHttpActionDescriptor.ExecuteAsync(HttpControllerContext controllerContext, IDictionary`2 arguments, CancellationToken cancellationToken)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at System.Web.Http.Controllers.ApiControllerActionInvoker.<InvokeActionAsyncCore>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at System.Web.Http.Controllers.ExceptionFilterResult.<ExecuteAsync>d__0.MoveNext()
```
