### PR TITLE
added null check for FrameworksExpiredRequired

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
@@ -23,7 +23,7 @@
     <add key="ApprenticeshipIndexAlias" value="localapprenticeshipindexalias" />
     <add key="ProviderIndexAlias" value="localproviderindexalias" />
     <add key="AssessmentOrgsIndexAlias" value="localassessmentorgsindexalias" />
-    <add key="ElasticServerUrls" value="" />
+    <add key="ElasticServerUrls" value="http://127.0.0.1:9200" />
     <add key="ElasticsearchUsername" value="" />
     <add key="ElasticsearchPassword" value="" />
     <add key="FrameworksExpiredRequired" value="" />

--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Settings/ApplicationSettings.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Settings/ApplicationSettings.cs
@@ -40,8 +40,6 @@
             }
         }
 
-        public int ProviderApprenticeshipsMaximum => int.Parse(ConfigurationManager.AppSettings["ProviderApprenticeshipsMaximum"]);
-
         private IEnumerable<Uri> GetElasticSearchIps()
         {
             var urlStrings = CloudConfigurationManager.GetSetting("ElasticServerUrls").Split(',');

--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Settings/ApplicationSettings.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Settings/ApplicationSettings.cs
@@ -28,12 +28,19 @@
         public string ElasticsearchUsername => ConfigurationManager.AppSettings["ElasticsearchUsername"];
 
         public string ElasticsearchPassword => ConfigurationManager.AppSettings["ElasticsearchPassword"];
-        public List<string> FrameworksExpiredRequired => GetFrameworksExpiredList();
 
-        private List<string> GetFrameworksExpiredList()
-        {
-            return CloudConfigurationManager.GetSetting("FrameworksExpiredRequired").Split(',').Where(s => s != string.Empty).Select(x => x.Trim()).ToList();
+        public List<string> FrameworksExpiredRequired {
+            get
+            {
+                return
+                    CloudConfigurationManager.GetSetting("FrameworksExpiredRequired")
+                    ?.Split(',')
+                    .Where(s => s != string.Empty).ToList()
+                ?? new List<string>();
+            }
         }
+
+        public int ProviderApprenticeshipsMaximum => int.Parse(ConfigurationManager.AppSettings["ProviderApprenticeshipsMaximum"]);
 
         private IEnumerable<Uri> GetElasticSearchIps()
         {


### PR DESCRIPTION
Hi @mapaux and @MarkFCain 
I think this will fix so FrameworksExpiredRequired can have null

The other change is that we haven't specified the different elastic urls. Think we do that in the indexer.
```xml 
add key="ElasticServerUrls" value="http://127.0.0.1:9200" />
```