### PR TITLE
CI-442 Update applicationException when failing to call for providers

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ApprenticeshipProviderRepository.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ApprenticeshipProviderRepository.cs
@@ -83,7 +83,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
             if (results.ApiCall.HttpStatusCode != 200)
             {
                 throw new ApplicationException(
-                    $"Failed query standard with provider. HttpStatusCode was {results.ApiCall.HttpStatusCode}", 
+                    $"Failed query standard with provider. HttpStatusCode was {results.ApiCall.HttpStatusCode}",
                     results.ApiCall.OriginalException);
             }
 

--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ApprenticeshipProviderRepository.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ApprenticeshipProviderRepository.cs
@@ -82,8 +82,9 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
 
             if (results.ApiCall.HttpStatusCode != 200)
             {
-                _applicationLogger.Warn($"httpStatusCode was {results.ApiCall.HttpStatusCode}");
-                throw new ApplicationException($"Failed query standard with provider");
+                throw new ApplicationException(
+                    $"Failed query standard with provider. HttpStatusCode was {results.ApiCall.HttpStatusCode}", 
+                    results.ApiCall.OriginalException);
             }
 
             var document = results.Documents.Any() ? results.Documents.First() : null;

--- a/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Repositories/ApprenticeshipProviderRepositoryTests.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Repositories/ApprenticeshipProviderRepositoryTests.cs
@@ -52,7 +52,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
 
             Assert.Throws<ApplicationException>(() => repo.GetCourseByStandardCode(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()));
 
-            _log.Verify(x => x.Warn(It.IsAny<string>()), Times.Once);
             _log.Verify(x => x.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
         }
 
@@ -74,7 +73,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
 
             Assert.Throws<ApplicationException>(() => repo.GetCourseByFrameworkId(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()));
 
-            _log.Verify(x => x.Warn(It.IsAny<string>()), Times.Once);
             _log.Verify(x => x.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
         }
     }


### PR DESCRIPTION
https://skillsfundingagency.atlassian.net/browse/CI-442

Checking the logs the last time we had an error with **25'A=0]**  was on October.

No sure we want to downgrade to **warn** but I removed the extra logging and added that information to the exception and added inner exception from elastic to our ApplicationException. 

/c