### PR TITLE
Ci 574 fixing apprenticeship details error

### DIFF
--- a/src/SFA.DAS.Apprenticeships.Api.Types/Providers/ApprenticeshipTrainingSummary.cs
+++ b/src/SFA.DAS.Apprenticeships.Api.Types/Providers/ApprenticeshipTrainingSummary.cs
@@ -7,7 +7,6 @@ namespace SFA.DAS.Apprenticeships.Api.Types.Providers
     {
         public long Ukprn { get; set; }        
         public PaginationDetails PaginationDetails { get; set; }
-        public int Count { get; set; }
         public IEnumerable<ApprenticeshipTraining> ApprenticeshipTrainingItems { get; set; }
 
     }

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
@@ -37,7 +37,6 @@
     <add key="CourseDirectoryUrl" value="https://dasapidev.coursedirectoryproviderportal.org.uk/dasapi/bulk/providers" />
     <add key="UKRLP_EndpointUri" value="" />
     <add key="AchievementRateDataBaseConnectionString" value="" />
-    <add key="TakeMaximum" value="1024" />
     <add key="PageSizeApprenticeshipSummary" value="20"/>
     <!--Logging-->
     <add key="LoggingRedisConnectionString" value="" />

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
@@ -37,7 +37,7 @@
     <add key="CourseDirectoryUrl" value="https://dasapidev.coursedirectoryproviderportal.org.uk/dasapi/bulk/providers" />
     <add key="UKRLP_EndpointUri" value="" />
     <add key="AchievementRateDataBaseConnectionString" value="" />
-    <add key="TakeMaximum" value="1000" />
+    <add key="TakeMaximum" value="1024" />
     <add key="PageSizeApprenticeshipSummary" value="20"/>
     <!--Logging-->
     <add key="LoggingRedisConnectionString" value="" />

--- a/src/Sfa.Das.ApprenticeshipInfoService.Core/Configuration/IConfigurationSettings.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Core/Configuration/IConfigurationSettings.cs
@@ -29,7 +29,6 @@
 
         List<string> StandardsExpiredRequired { get; }
 
-        int TakeMaximum { get; }
-        int PageSizeApprenticeshipSummary { get; }
+         int PageSizeApprenticeshipSummary { get; }
     }
 }

--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ProviderRepository.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ProviderRepository.cs
@@ -152,7 +152,11 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                 throw new ApplicationException($"Failed to query provider frameworks for ukprn [{ukprn}]");
             }
 
-            var totalTakeForFrameworkDocuments = _queryHelper.GetFrameworksTotalAmount();
+            var totalTakeForFrameworkDocuments = 0;
+            if (matchedIds.Documents.Count > 0)
+            {
+                totalTakeForFrameworkDocuments = _queryHelper.GetFrameworksTotalAmount();
+            }
 
             var providerFrameworks =
                 _elasticsearchCustomClient.Search<ProviderFramework>(
@@ -197,7 +201,12 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
                  throw new ApplicationException($"Failed to query provider standards for ukprn [{ukprn}]");
             }
 
-            var totalTakeForStandardDocuments = _queryHelper.GetStandardsTotalAmount();
+            var totalTakeForStandardDocuments = 0;
+
+            if (matchedIds.Documents.Count>0)
+            {
+                totalTakeForStandardDocuments = _queryHelper.GetStandardsTotalAmount();
+            }
 
             var providerStandards =
                 _elasticsearchCustomClient.Search<ProviderStandard>(

--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ProviderRepository.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Elasticsearch/ProviderRepository.cs
@@ -37,7 +37,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
             IProviderLocationSearchProvider providerLocationSearchProvider,
             IProviderMapping providerMapping,
             IQueryHelper queryHelper,
-            IActiveApprenticeshipChecker activeApprenticeshipChecker, 
+            IActiveApprenticeshipChecker activeApprenticeshipChecker,
             IPaginationHelper paginationHelper)
         {
             _elasticsearchCustomClient = elasticsearchCustomClient;
@@ -321,7 +321,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.Elasticsearch
             var pageSize = _applicationSettings.PageSizeApprenticeshipSummary;
             var paginationDetails = _paginationHelper.GeneratePaginationDetails(page, pageSize, totalCount);
             apprenticeshipTrainingSummary.PaginationDetails = paginationDetails;
-            apprenticeshipTrainingSummary.Count = totalCount;
 
             apprenticeshipTrainingSummary.ApprenticeshipTrainingItems
                 = apprenticeships.OrderBy(x => x.Name)

--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Settings/ApplicationSettings.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/Settings/ApplicationSettings.cs
@@ -28,8 +28,7 @@
         public string ElasticsearchUsername => ConfigurationManager.AppSettings["ElasticsearchUsername"];
 
         public string ElasticsearchPassword => ConfigurationManager.AppSettings["ElasticsearchPassword"];
-        public int TakeMaximum => int.Parse(ConfigurationManager.AppSettings["TakeMaximum"]);
-
+   
         public int PageSizeApprenticeshipSummary => int.Parse(
             ConfigurationManager.AppSettings["PageSizeApprenticeshipSummary"]);
 

--- a/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Repositories/ProviderRepositoryTests.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.UnitTests/Repositories/ProviderRepositoryTests.cs
@@ -22,7 +22,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
     [TestFixture]
     public class ProviderRepositoryTests
     {
-        private const int TakeMaximum = 10;
         private const int PageSizeApprenticeshipSummary = 4;
         private Mock<IElasticsearchCustomClient> _elasticClient;
 
@@ -45,8 +44,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             _queryHelper.Setup(x => x.GetProvidersByStandardTotalAmount(It.IsAny<string>())).Returns(1);
             _queryHelper.Setup(x => x.GetProvidersTotalAmount()).Returns(1);
             _mockConfigurationSettings = new Mock<IConfigurationSettings>();
-            _mockConfigurationSettings.Setup(x => x.TakeMaximum)
-                .Returns(TakeMaximum);
+
             _mockConfigurationSettings.Setup(x => x.PageSizeApprenticeshipSummary)
                 .Returns(PageSizeApprenticeshipSummary);
             _mockPaginationHelper = new Mock<IPaginationHelper>();
@@ -163,9 +161,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
 
             searchResponseForFrameworkDtos.Setup(x => x.Documents).Returns(new List<ProviderFrameworkDto> { frameworkDto1, frameworkDto2 });
 
-            var configurationSettings = new Mock<IConfigurationSettings>();
-            configurationSettings.Setup(x => x.TakeMaximum).Returns(2);
-            apiCallForFrameworkDtos.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);
+         apiCallForFrameworkDtos.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);
             searchResponseForFrameworkDtos.SetupGet(x => x.ApiCall).Returns(apiCallForFrameworkDtos.Object);
 
             apiCallForFrameworks.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.Ambiguous);
@@ -176,7 +172,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             var repo = new ProviderRepository(
                 _elasticClient.Object,
                 _log.Object,
-                configurationSettings.Object,
+                Mock.Of<IConfigurationSettings>(),
                 Mock.Of<IProviderLocationSearchProvider>(),
                 Mock.Of<IProviderMapping>(),
                 _queryHelper.Object,
@@ -207,8 +203,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
 
             searchResponseForFrameworks.Setup(x => x.Documents).Returns(providerFrameworks);
 
-            var configurationSettings = new Mock<IConfigurationSettings>();
-            configurationSettings.Setup(x => x.TakeMaximum).Returns(10);
             apiCallForFrameworkDtos.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);
             searchResponseForFrameworkDtos.SetupGet(x => x.ApiCall).Returns(apiCallForFrameworkDtos.Object);
 
@@ -220,7 +214,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             var repo = new ProviderRepository(
                 _elasticClient.Object,
                 _log.Object,
-                configurationSettings.Object,
+                Mock.Of<IConfigurationSettings>(),
                 Mock.Of<IProviderLocationSearchProvider>(),
                 Mock.Of<IProviderMapping>(),
                 _queryHelper.Object,
@@ -273,8 +267,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
 
             searchResponseForStandardsDtos.Setup(x => x.Documents).Returns(new List<ProviderStandardDto> { standardDto1, standardDto2 });
 
-            var configurationSettings = new Mock<IConfigurationSettings>();
-            configurationSettings.Setup(x => x.TakeMaximum).Returns(2);
             apiCallForStandardDtos.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);
             searchResponseForStandardsDtos.SetupGet(x => x.ApiCall).Returns(apiCallForStandardDtos.Object);
 
@@ -286,7 +278,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             var repo = new ProviderRepository(
                 _elasticClient.Object,
                 _log.Object,
-                configurationSettings.Object,
+                Mock.Of<IConfigurationSettings>(),
                 Mock.Of<IProviderLocationSearchProvider>(),
                 Mock.Of<IProviderMapping>(),
                 _queryHelper.Object,
@@ -318,8 +310,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             };
             searchResponse.Setup(x => x.Documents).Returns(providerStandards);
 
-            var configurationSettings = new Mock<IConfigurationSettings>();
-            configurationSettings.Setup(x => x.TakeMaximum).Returns(10);
             apiCallForDtos.SetupGet(x => x.HttpStatusCode).Returns((int) HttpStatusCode.OK);
             searchResponseForDtos.SetupGet(x => x.ApiCall).Returns(apiCallForDtos.Object);
 
@@ -331,7 +321,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             var repo = new ProviderRepository(
                 _elasticClient.Object,
                 _log.Object,
-                configurationSettings.Object,
+                Mock.Of<IConfigurationSettings>(),
                 Mock.Of<IProviderLocationSearchProvider>(),
                 Mock.Of<IProviderMapping>(),
                 _queryHelper.Object,
@@ -407,8 +397,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             searchResponseForDtos.Setup(x => x.Documents).Returns(new List<ProviderStandardDto> { new ProviderStandardDto() });
             searchResponseForFrameworkDtos.Setup(x => x.Documents).Returns(new List<ProviderFrameworkDto>());
 
-            var configurationSettings = new Mock<IConfigurationSettings>();
-            configurationSettings.Setup(x => x.TakeMaximum).Returns(10);
             apiCallForDtos.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);
             searchResponseForDtos.SetupGet(x => x.ApiCall).Returns(apiCallForDtos.Object);
             apiCallForStandards.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);
@@ -490,7 +478,7 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
 
             var providerApprenticeships = result.ApprenticeshipTrainingItems.ToArray();
             Assert.AreEqual(PageSizeApprenticeshipSummary, providerApprenticeships.Length);
-            Assert.AreEqual(4, result.Count);
+            Assert.AreEqual(4, result.PaginationDetails.TotalCount);
             Assert.AreEqual(providerApprenticeships[0].Identifier, providerFrameworkAccountingLev2.FrameworkId,
                 $"Expect first item to be Framework Id [{providerFrameworkAccountingLev2.FrameworkId}], but was [{providerApprenticeships[0].Identifier} ]");
             Assert.AreEqual(providerApprenticeships[1].Identifier, providerFrameworkAccountingLev3.FrameworkId);
@@ -522,8 +510,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.UnitTests.Repositories
             searchResponseForDtos.Setup(x => x.Documents).Returns(new List<ProviderStandardDto> { new ProviderStandardDto() });
             searchResponseForFrameworkDtos.Setup(x => x.Documents).Returns(new List<ProviderFrameworkDto>());
 
-            var configurationSettings = new Mock<IConfigurationSettings>();
-            configurationSettings.Setup(x => x.TakeMaximum).Returns(10);
             apiCallForDtos.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);
             searchResponseForDtos.SetupGet(x => x.ApiCall).Returns(apiCallForDtos.Object);
             apiCallForStandards.SetupGet(x => x.HttpStatusCode).Returns((int)HttpStatusCode.OK);


### PR DESCRIPTION
Hi chaps, this is an update caused by incorrect data coming back from the api.  Now fixed.  I tagged it to this story as it can't pass PO without this fix.  

Once you have okayed this, I'll update the das-search code to point to the new API, and then push that through (there will be no code changes, just reference updates, so won't bother requesting code rewview for the das-search update)

@mapaux if this gets okayed, will it be okay to merge into master, or will that cause problems with the imminent release?