### PR TITLE
CI-804 - Redirect all requests

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Global.asax.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Global.asax.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Azure;
-using NLog.Internal;
 using SFA.DAS.NLog.Logger;
-using ConfigurationManager = System.Configuration.ConfigurationManager;
 
 namespace Sfa.Das.ApprenticeshipInfoService.Api
 {

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Global.asax.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Global.asax.cs
@@ -1,4 +1,7 @@
-﻿using SFA.DAS.NLog.Logger;
+﻿using Microsoft.Azure;
+using NLog.Internal;
+using SFA.DAS.NLog.Logger;
+using ConfigurationManager = System.Configuration.ConfigurationManager;
 
 namespace Sfa.Das.ApprenticeshipInfoService.Api
 {
@@ -56,6 +59,15 @@ namespace Sfa.Das.ApprenticeshipInfoService.Api
                 && !context.Request.Path.StartsWith("/__browserlink"))
             {
                 _logger.Info($"{context.Request.HttpMethod} {context.Request.Path}");
+            }
+
+            var redirectUrl = CloudConfigurationManager.GetSetting("RedirectUrl");
+            if (!string.IsNullOrEmpty(redirectUrl))
+            {
+                var requestRawUrl = application?.Context?.Request.RawUrl;
+                _logger.Info($"Redirecting request from UserHost:{context.Request.UserHostAddress} to {redirectUrl} for request {requestRawUrl}");
+
+                Response.RedirectPermanent($"{redirectUrl}{requestRawUrl}");
             }
         }
     }

--- a/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Api/Web.config
@@ -42,6 +42,7 @@
     <!--Logging-->
     <add key="LoggingRedisConnectionString" value="" />
     <add key="LoggingRedisKey" value="logstash" />
+    <add key="RedirectUrl" value="" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.


### PR DESCRIPTION
If there is a setting for the RedirectUrl, then in the
Application_BeginRequest the Response will be redirected to the value
set in the configuration value.

CloudConfigurationManager has been used instead of ConfigurationManager
incase this comes into the ES5 branch. Default behaviour is to fallback
to Web.config setting if no setting exists in the cloud configuration