### PR TITLE
Removes logging redis cache health check

### DIFF
--- a/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/DependencyResolution/ServiceCollectionExtensions.cs
+++ b/src/Sfa.Das.ApprenticeshipInfoService.Infrastructure/DependencyResolution/ServiceCollectionExtensions.cs
@@ -56,7 +56,6 @@ namespace Sfa.Das.ApprenticeshipInfoService.Infrastructure.DependencyResolution
             services.AddScoped<IProviderNameSearchMapping, ProviderNameSearchMapping>();
 
             services.AddHealthChecks()
-                .AddRedis(configuration.GetConnectionString("Redis"), "redis-check")
                 .AddCheck<ElasticsearchHealthCheck>("elasticsearch-query-check");
         }
     }


### PR DESCRIPTION
This PR removes the health check for the logging Redis cache.

The application should not fail it's checks if this service is down as it can cause a domino effect with infrastructure checks and other services.
